### PR TITLE
Standardize usage of `newline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Options can be be passed to the constructor to customize behaviour.
 
 **bg** <code>CSS color values</code> The default background color used when reset color codes are encountered.
 
-**newLine** <code>true or false</code> Convert newline characters to <code>&lt;br/&gt;</code>.
+**newline** <code>true or false</code> Convert newline characters to <code>&lt;br/&gt;</code>.
 
 **escapeXML** <code>true or false</code> Generate HTML/XML entities.
 

--- a/src/ansi_to_html.coffee
+++ b/src/ansi_to_html.coffee
@@ -70,7 +70,7 @@ extend = (dest, objs...) ->
 defaults =
 	fg: '#FFF'
 	bg: '#000'
-	newLine: false
+	newline: false
 	escapeXML: false
 	stream: false
 


### PR DESCRIPTION
Currently both the documentation and default options refer to `newLine`, while the actual variable the code uses is `newline`. This patch fixes that, by changing the documentation and defaults to be in line with the module behaviour.

This patch should not introduce API breakage.