### PR TITLE
karg version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "entities": "^1.1.1",
-    "karg": "^0.2.1"
+    "karg": "^1.0.4"
   },
   "bin": {
     "ansi-to-html": "./bin/ansi-to-html"


### PR DESCRIPTION
hi rburns,
there was a problem in my karg package that prevented windows users to install the ansi-to-html package.
This pull request updates to the latest karg version which includes the fix.
It would be great if you could publish this to npm once more.
Sorry for the inconvenience,
Yours monsterkodi
