### PR TITLE
Annotate Filter with types in JSDoc comments.

### DIFF
--- a/src/ansi_to_html.js
+++ b/src/ansi_to_html.js
@@ -466,6 +466,15 @@ function updateStickyStack(stickyStack, token, data) {
 }
 
 class Filter {
+    /**
+     * @param {object} options
+     * @param {string=} options.fg The default foreground color used when reset color codes are encountered.
+     * @param {string=} options.bg The default background color used when reset color codes are encountered.
+     * @param {boolean=} options.newline Convert newline characters to `<br/>`.
+     * @param {boolean=} options.escapeXML Generate HTML/XML entities.
+     * @param {boolean=} options.stream Save style state across invocations of `toHtml()`.
+     * @param {(string[] | {[code: number]: string})=} options.colors Can override specific colors or the entire ANSI palette. 
+     */
     constructor (options) {
         options = options || {};
 
@@ -477,6 +486,10 @@ class Filter {
         this.stack = [];
         this.stickyStack = [];
     }
+    /**
+     * @param {string | string[]} input
+     * @returns {string}
+     */
     toHtml (input) {
         input = typeof input === 'string' ? [input] : input;
         const {stack, options} = this;


### PR DESCRIPTION
Hi! I've annotated Filter with types in JSDoc comments.
It improves the DX for `ansi-to-html` users

### Before
![Annotation 2019-10-09 235949](https://user-images.githubusercontent.com/15332326/66523894-4492cc80-eaf1-11e9-956f-47223f453290.png)

### After
![Annotation 2019-10-09 235529](https://user-images.githubusercontent.com/15332326/66523973-6d1ac680-eaf1-11e9-837c-00940f2fc054.png)

It can be used to generate TypeScript declaration file (#52).