### PR TITLE
NPM scripts - add watch modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options can be be passed to the constructor to customize behaviour.
 
 ### Default options
 
-```javascript
+```json5
 {
     fg: '#FFF',
     bg: '#000',
@@ -88,20 +88,35 @@ cd ansi-to-html
 npm install
 ```
 
-Lint
+#### Lint
 
 ```bash
 npm run lint
 ```
 
-Build
+#### Build
 
 ```bash
 npm run build
 ```
 
-Test
+- Builds the `/src` files by running `babel`. 
+- Saves the built files in `/lib` output directory. 
+- Recommended to run `babel` in Watch mode - will re-build the project each time the files are changed.
+```bash
+npm run build:watch
+```
+
+#### Test
 
 ```bash
 npm test
 ```
+- Note: Runs the tests against the built files (in the `/lib` directory).
+- You also run the tests in watch mode (will rerun tests when files are changed).
+- Recommended to run the build in watch mode as well to re-build the project before the tests are run.
+
+```bash
+npm run test:watch
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ansi-to-html",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   },
   "scripts": {
     "build": "babel src --out-dir lib",
+    "build:watch": "babel src --out-dir lib --watch",
     "lint": "eslint src test",
-    "test": "mocha --reporter tap"
+    "test": "mocha --reporter tap",
+    "test:watch": "mocha --reporter tap --watch ./test ./"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Problem description
- When changing code and running tests i forgot to re-run the build process causing a lot of friction trying to debug why the new tests are failing while the code tested is the previous version of the `/src` files.

### Suggested Solution
Added Watch modes for the `build` and `test` scripts to support running the tests each time a file is changed.
- The `test:watch` script will run tests each time they are changed. ( or the `/src` / `/lib` directory files are changed).
- The `build:watch` script will run the build each time the `/src` files are changed - this will also help the developer receive real feedback for the changes he made to the `/src` files and not mistake the tests passing / failing when they run against the previous (and now stale) build.
- Updated the `README.md` to include these changes and recommend using the watch modes added.
- Also did some minor markdown changes to the `README.md` file: 
-- Changed the Lint / Build / Test subtitles in the Development section to  sub-headings.
-- Changed the markdown type for the default options JSON snippet to be  `json5` and not `javascript`.