### PR TITLE
Support windows style newline

### DIFF
--- a/src/ansi_to_html.js
+++ b/src/ansi_to_html.js
@@ -383,6 +383,9 @@ function tokenize(text, options, callback) {
     }, {
         pattern: /^\n/,
         sub: newline
+    },{
+        pattern: /^\r\n/,
+        sub: newline
     }, {
         pattern: /^\x1b\[((?:\d{1,3};?)+|)m/,
         sub: ansiMess
@@ -406,7 +409,14 @@ function tokenize(text, options, callback) {
         pattern: /^\x1b\[?[\d;]{0,3}/,
         sub: remove
     }, {
-        pattern: /^([^\x1b\x08\n]+)/,
+        /**
+         * extracts real text - not containing:
+         * - `\x1b' - ESC - escape (Ascii 27)
+         * - '\x08' - BS - backspace (Ascii 8)
+         * - `\n` - Newline - linefeed (LF) (ascii 10)
+         * - `\r` - Windows Carriage Return (CR)
+         */
+        pattern: /^(([^\x1b\x08\r\n])+)/,
         sub: realText
     }];
 
@@ -473,7 +483,7 @@ class Filter {
      * @param {boolean=} options.newline Convert newline characters to `<br/>`.
      * @param {boolean=} options.escapeXML Generate HTML/XML entities.
      * @param {boolean=} options.stream Save style state across invocations of `toHtml()`.
-     * @param {(string[] | {[code: number]: string})=} options.colors Can override specific colors or the entire ANSI palette. 
+     * @param {(string[] | {[code: number]: string})=} options.colors Can override specific colors or the entire ANSI palette.
      */
     constructor (options) {
         options = options || {};

--- a/test/ansi_to_html.js
+++ b/test/ansi_to_html.js
@@ -27,9 +27,16 @@ describe('ansi to html', function () {
             return test(text, result, done);
         });
 
-        it('returns plain text when given plain text', function (done) {
+        it('returns plain text when given plain text with linefeed', function (done) {
             const text = 'test\ntest\n';
             const result = 'test\ntest\n';
+
+            return test(text, result, done);
+        });
+
+        it('returns plain text when given plain text with CR & LF', function (done) {
+            const text = 'testCRLF\r\ntest';
+            const result = 'testCRLF\r\ntest';
 
             return test(text, result, done);
         });
@@ -314,6 +321,13 @@ describe('ansi to html', function () {
         it('renders line breaks', function (done) {
             const text = 'test\ntest\n';
             const result = 'test<br/>test<br/>';
+
+            return test(text, result, done, {newline: true});
+        });
+
+        it('renders windows styled line breaks (CR+LF)', function (done) {
+            const text = 'testCRLF\r\ntestLF';
+            const result = 'testCRLF<br/>testLF';
 
             return test(text, result, done, {newline: true});
         });


### PR DESCRIPTION
### Problem description
-When handling Ansi escaped text came across the `\r\n` which is commonly used by windows to designate a newline. 
-Currently `\r` is simply ignored (treated as normal text)

### Suggested Solution
- To support converting the newline to <br/> added the `\r` to two patterns :
  - one is the `\r\n` to add a newline when encountered
  - the other is the last pattern, which extracts the text itself without newlines or backspaces or escape char.
![image](https://user-images.githubusercontent.com/45829076/67652196-8bcfe880-f94c-11e9-85d5-0808be921ffd.png)




This is a reference i found to elaborate on the issue from [stackoverflow](https://stackoverflow.com/questions/15433188/r-n-r-and-n-what-is-the-difference-between-them):

\r = CR (Carriage Return) → Used as a new line character in Mac OS before X
\n = LF (Line Feed) → Used as a new line character in Unix/Mac OS X
\r\n = CR + LF → Used as a new line character in Windows

Updated and Added two tests - when newline option is `false` and when it is `true`
