### PR TITLE
Linting/Strict fix

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+lib
+coverage

--- a/bin/ansi-to-html
+++ b/bin/ansi-to-html
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
+'use strict';
 require('../lib/cli.js');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "babel src --out-dir lib",
     "build:watch": "babel src --out-dir lib --watch",
-    "lint": "eslint src test",
+    "lint": "eslint .",
     "test": "mocha --reporter tap",
     "test:watch": "mocha --reporter tap --watch ./test ./"
   },


### PR DESCRIPTION
- Lint all files by default, adding an ignore to exclude build or coverage files
- Add missing strict directive (caught now by linting)

(Relying on an ignore file also has the advantage that IDE linters can pick up on the fact that certain files in a package should not be linted.)