### PR TITLE
`space` and `tabs` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ npm install ansi-to-html
 ## Usage
 
 ```javascript
-var Convert = require('ansi-to-html');
-var convert = new Convert();
+const Convert = require('ansi-to-html');
+const convert = new Convert();
 
 console.log(convert.toHtml('\x1b[30mblack\x1b[37mwhite'));
 
@@ -60,6 +60,10 @@ Options can be be passed to the constructor to customize behaviour.
 **bg** `<CSS color values>`. The default background color used when reset color codes are encountered.
 
 **newline** `true` or `false`. Convert newline characters to `<br/>`.
+
+**space** `true` or `false` (default). Convert any two sequential spaces to ` &#xa0;` (a space followed by a non-breaking space). You will probably wish to use this with a fixed width font, e.g., `font-family: monospace;`.
+
+**tabs** `null` (default) or a number. Converts tabs to a given number of non-breaking spaces (`&#xa0;`).
 
 **escapeXML** `true` or `false`. Generate HTML/XML entities.
 
@@ -100,8 +104,8 @@ npm run lint
 npm run build
 ```
 
-- Builds the `/src` files by running `babel`. 
-- Saves the built files in `/lib` output directory. 
+- Builds the `/src` files by running `babel`.
+- Saves the built files in `/lib` output directory.
 - Recommended to run `babel` in Watch mode - will re-build the project each time the files are changed.
 ```bash
 npm run build:watch
@@ -119,4 +123,3 @@ npm test
 ```bash
 npm run test:watch
 ```
-

--- a/src/ansi_to_html.js
+++ b/src/ansi_to_html.js
@@ -4,6 +4,8 @@ const defaults = {
     fg: '#FFF',
     bg: '#000',
     newline: false,
+    space: false,
+    tabs: null,
     escapeXML: false,
     stream: false,
     colors: getDefaultColors()
@@ -97,14 +99,21 @@ function toColorHexString(ref) {
  * @param {object} options
  */
 function generateOutput(stack, token, data, options) {
+    const {tabs, space, colors} = options;
     let result;
 
     if (token === 'text') {
+        if (space) {
+            data = data.replace(/ {2}/g, ' &#xa0;');
+        }
+        if (tabs) {
+            data = data.replace(/\t/g, '&#xa0;'.repeat(tabs));
+        }
         result = pushText(data, options);
     } else if (token === 'display') {
         result = handleDisplay(stack, data, options);
     } else if (token === 'xterm256') {
-        result = pushForegroundColor(stack, options.colors[data]);
+        result = pushForegroundColor(stack, colors[data]);
     } else if (token === 'rgb') {
         result = handleRgb(stack, data);
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 'use strict';
 /* eslint no-console:0 */
-const help = '\nuasge: ansi-to-html [options] [file]\n    \nfile:  The file to display or stdin\n    \noptions:    \n    \n    -f, --fg         The background color used for resets (#000)\n    -b, --bg         The foreground color used for resets (#FFF)\n    -n, --newline    Convert newline characters to <br/>  (false)\n    -x, --escapeXML  Generate XML entities                (false)\n    -v, --version    Print version\n    -h, --help       Print help\n    ';
+const help = '\nusage: ansi-to-html [options] [file]\n    \nfile:  The file to display or stdin\n    \noptions:    \n    \n    -f, --fg         The background color used for resets (#000)\n    -b, --bg         The foreground color used for resets (#FFF)\n    -n, --newline    Convert newline characters to <br/>  (false)\n    -x, --escapeXML  Generate XML entities                (false)\n    -v, --version    Print version\n    -h, --help       Print help\n    ';
 const args = {
     stream: true
 };

--- a/test/ansi_to_html.js
+++ b/test/ansi_to_html.js
@@ -355,6 +355,24 @@ describe('ansi to html', function () {
         });
     });
 
+    describe('with `space` option enabled', function () {
+        it('renders multiple spaces', function (done) {
+            const text = 'test  test  ';
+            const result = 'test &#xa0;test &#xa0;';
+
+            return test(text, result, done, {space: true});
+        });
+    });
+
+    describe('with `tabs` option enabled', function () {
+        it('renders multiple tabs', function (done) {
+            const text = 'test\ttest\t';
+            const result = 'test&#xa0;&#xa0;&#xa0;test&#xa0;&#xa0;&#xa0;';
+
+            return test(text, result, done, {tabs: 3});
+        });
+    });
+
     describe('with stream option enabled', function () {
         it('persists styles between toHtml() invocations', function (done) {
             const text = ['\x1b[31mred', 'also red'];


### PR DESCRIPTION
- Enhancement: Add `space` and `tabs` options

Also uses `const` in README and fixes typo in sp. (of "usage") in CLI help