### PR TITLE
Support background 256 colors.

### DIFF
--- a/src/ansi_to_html.js
+++ b/src/ansi_to_html.js
@@ -104,12 +104,29 @@ function generateOutput(stack, token, data, options) {
     } else if (token === 'display') {
         result = handleDisplay(stack, data, options);
     } else if (token === 'xterm256') {
-        result = pushForegroundColor(stack, options.colors[data]);
+        result = handleXterm256(stack, data, options);
     } else if (token === 'rgb') {
         result = handleRgb(stack, data);
     }
 
     return result;
+}
+
+/**
+ * @param {Array} stack
+ * @param {string} data
+ * @param {object} options
+ * @returns {*}
+ */
+function handleXterm256(stack, data, options) {
+    data = data.substring(2).slice(0, -1);
+    const operation = +data.substr(0,2);
+    const color = +data.substr(5);
+    if (operation === 38) {
+        return pushForegroundColor(stack, options.colors[color]);
+    } else {
+        return pushBackgroundColor(stack, options.colors[color]);
+    }
 }
 
 /**
@@ -323,8 +340,8 @@ function tokenize(text, options, callback) {
         return '';
     }
 
-    function removeXterm256(m, g1) {
-        callback('xterm256', g1);
+    function removeXterm256(m) {
+        callback('xterm256', m);
         return '';
     }
 
@@ -379,7 +396,7 @@ function tokenize(text, options, callback) {
         pattern: /^\x1b\[[34]8;2;\d+;\d+;\d+m/,
         sub: rgb
     }, {
-        pattern: /^\x1b\[38;5;(\d+)m/,
+        pattern: /^\x1b\[[34]8;5;\d+m/,
         sub: removeXterm256
     }, {
         pattern: /^\n/,

--- a/test/ansi_to_html.js
+++ b/test/ansi_to_html.js
@@ -154,9 +154,16 @@ describe('ansi to html', function () {
             return test(text, result, done);
         });
 
-        it('renders xterm 256 sequences', function (done) {
+        it('renders xterm foreground 256 sequences', function (done) {
             const text = '\x1b[38;5;196mhello';
             const result = '<span style="color:#ff0000">hello</span>';
+
+            return test(text, result, done);
+        });
+
+        it('renders xterm background 256 sequences', function (done) {
+            const text = '\x1b[48;5;196mhello';
+            const result = '<span style="background-color:#ff0000">hello</span>';
 
             return test(text, result, done);
         });


### PR DESCRIPTION
Current version does not handle 6x6x6 216 colors for background starting with "\e[48;5;".
I also need to handle both foreground and background setting in the same sequence, but it is beyond quick work.

This is my very first JavaScript program.  Please discard and rewrite if not appropriate.