### PR TITLE
Add support for xterm256 background color sequences

### DIFF
--- a/test/ansi_to_html.js
+++ b/test/ansi_to_html.js
@@ -154,9 +154,16 @@ describe('ansi to html', function () {
             return test(text, result, done);
         });
 
-        it('renders xterm 256 sequences', function (done) {
+        it('renders xterm 256 foreground sequences', function (done) {
             const text = '\x1b[38;5;196mhello';
             const result = '<span style="color:#ff0000">hello</span>';
+
+            return test(text, result, done);
+        });
+
+        it('renders xterm 256 background sequences', function (done) {
+            const text = '\x1b[48;5;196mhello';
+            const result = '<span style="background-color:#ff0000">hello</span>';
 
             return test(text, result, done);
         });


### PR DESCRIPTION
Hey there Rob

I've just picked up a fun project of building a simple web-based terminal and your library is of great help, so first of all thanks a lot for your work!

I am anything but an expert of ANSI escape codes, but with the help of Wikipedia et. al, I tried to add support for 8bit/256-color background sequences. What do you think about these changes? I hope I got the naming and formatting right.

Commit Description:
* Currently, only 8bit/256-color foreground sequences are supported (ESC[ 38;5;⟨n⟩ m)
* This PR adds additional patterns for 8bit/256-color background sequences (ESC[ 48;5;⟨n⟩ m) 

Thanks for looking into it,
remolueoend 
