### PR TITLE
Bugfix/82 failure slash r sequence

### DIFF
--- a/src/ansi_to_html.js
+++ b/src/ansi_to_html.js
@@ -398,8 +398,8 @@ function tokenize(text, options, callback) {
         pattern: /^\r+\n/,
         sub: newline
     }, {
-        pattern: /^\r+/,
-        sub: remove
+        pattern: /^\r/,
+        sub: newline
     }, {
         pattern: /^\x1b\[((?:\d{1,3};?)+|)m/,
         sub: ansiMess

--- a/src/ansi_to_html.js
+++ b/src/ansi_to_html.js
@@ -398,6 +398,9 @@ function tokenize(text, options, callback) {
         pattern: /^\r+\n/,
         sub: newline
     }, {
+        pattern: /^\r+/,
+        sub: remove
+    }, {
         pattern: /^\x1b\[((?:\d{1,3};?)+|)m/,
         sub: ansiMess
     }, {

--- a/test/ansi_to_html.js
+++ b/test/ansi_to_html.js
@@ -322,9 +322,9 @@ describe('ansi to html', function () {
             return test(text, result, done);
         });
 
-        it('renders text following carriage return', function (done) {
+        it('renders text following carriage return (CR, mac style line break)', function (done) {
             const text = 'ANSI Hello\rWorld';
-            const result = 'ANSI HelloWorld';
+            const result = 'ANSI Hello\rWorld';
 
             return test(text, result, done);
         });
@@ -363,6 +363,20 @@ describe('ansi to html', function () {
 
         it('renders multiple line breaks', function (done) {
             const text = 'test\n\ntest\n';
+            const result = 'test<br/><br/>test<br/>';
+
+            return test(text, result, done, {newline: true});
+        });
+
+        it('renders mac styled line breaks (CR)', function (done) {
+            const text = 'test\rtest\r';
+            const result = 'test<br/>test<br/>';
+
+            return test(text, result, done, {newline: true});
+        });
+
+        it('renders multiple mac styled line breaks (CR)', function (done) {
+            const text = 'test\r\rtest\r';
             const result = 'test<br/><br/>test<br/>';
 
             return test(text, result, done, {newline: true});


### PR DESCRIPTION
fixes #82 

`\r` will be handled like the other line break styles (`\n` or `\r\n`): pass through by default, `<br/>` when `newLine` option is set.

I referenced is as the "mac style" line break in the tests as it seems to be the old way for Mac OS to represent line breaks